### PR TITLE
fix: fixing issue with site overrides being overwritten by semantic u…

### DIFF
--- a/oarepo_theme/assets/semantic-ui/less/oarepo/theme.less
+++ b/oarepo_theme/assets/semantic-ui/less/oarepo/theme.less
@@ -81,6 +81,9 @@ Sample output:
 /* Site theme variables for a component */
 @import (optional, multiple) "@{siteFolder}/@{theme}/@{type}s/@{element}.variables";
 
+/* Final variable overrides for components */
+@import (optional, multiple) "@{siteFolder}/@{type}s/@{element}.variables";
+
 /*******************************
              Mix-ins
 *******************************/

--- a/tests/test_webpack.py
+++ b/tests/test_webpack.py
@@ -15,7 +15,7 @@ from oarepo_runtime.cli.assets import enumerate_assets
 
 def test_webpack_themes(ui_app):
     with ui_app.app_context():
-        aliases, asset_dirs, generated_paths = enumerate_assets()
+        aliases, _asset_dirs, generated_paths = enumerate_assets()
         assert "../../theme.config$" in aliases
         assert "../../less/site" in aliases
         assert "../../less" in aliases


### PR DESCRIPTION
…i defaults

We are missing at the end of imports related to components the import that is directly in site (not nested under a theme). I.e. https://github.com/inveniosoftware/invenio-app-rdm/blob/f313791da923031c2a20b8ade491490c888cd786/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/theme.less#L47