### PR TITLE
Revert "using rdm theme for all cmps"

### DIFF
--- a/oarepo_theme/assets/semantic-ui/less/theme.config
+++ b/oarepo_theme/assets/semantic-ui/less/theme.config
@@ -19,7 +19,7 @@
 
 /* Global */
 @site        : 'rdm';
-@reset       : 'rdm';
+@reset       : 'default';
 
 /* Elements */
 @button      : 'rdm';
@@ -27,7 +27,7 @@
 @divider     : 'rdm';
 @flag        : 'rdm';
 @header      : 'rdm';
-@icon        : 'rdm';
+@icon        : 'default';
 @image       : 'rdm';
 @input       : 'rdm';
 @label       : 'rdm';
@@ -63,7 +63,7 @@
 @sidebar     : 'rdm';
 @sticky      : 'rdm';
 @tab         : 'rdm';
-@transition  : 'rdm';
+@transition  : 'default';
 
 /* Views */
 @ad          : 'rdm';


### PR DESCRIPTION
This reverts commit 14f02898284461aafb4620c87085ba516237492c.

Previous commit broke RDM build:

```
× Module not found: Can't resolve './themes/rdm/assets/fonts/icons.woff2' in
``` 